### PR TITLE
Civil Twilight Sunrise Time

### DIFF
--- a/src/vscp/common/vscpautomation.cpp
+++ b/src/vscp/common/vscpautomation.cpp
@@ -602,9 +602,9 @@ bool CVSCPAutomation::doWork( vscpEventEx *pEventEx )
         pEventEx->vscp_type = VSCP_TYPE_INFORMATION_SUNRISE_TWILIGHT_START;
         pEventEx->sizeData = 3;
         // IMPORTANT - GUID must be set by caller before event is sent
-        pEventEx->data[ 0 ] = m_zone;       // index
-        pEventEx->data[ 1 ] = m_subzone;    // zone
-        pEventEx->data[ 2 ] = 0;            // subzone
+        pEventEx->data[ 0 ] = 0;            // index
+        pEventEx->data[ 1 ] = m_zone;       // zone
+        pEventEx->data[ 2 ] = m_subzone;    // subzone
 
         return true;
     }


### PR DESCRIPTION
Setting of Zone and Subzone got mixed up for 'Civil Twilight Sunrise Time' event.