### PR TITLE
Fix can232 driver for Linux after #101

### DIFF
--- a/src/vscp/drivers/level1/can232/linux/can232obj.cpp
+++ b/src/vscp/drivers/level1/can232/linux/can232obj.cpp
@@ -680,7 +680,7 @@ void *workThread(void *pObject)
                                     printf("%02X ", pcan232obj->m_can232obj.m_receiveBuf[i]);
                                 }
                                 printf("]\n");
-                                if (!can232ToCanal(pcan232obj->m_can232obj.m_receiveBuf, pMsg)) {
+                                if (can232ToCanal(pcan232obj->m_can232obj.m_receiveBuf, pMsg)) {
                                     pNode->pObject = pMsg;
                                     dll_addNode(&pcan232obj->m_can232obj.m_rcvList, pNode);
                                     // Update statistics


### PR DESCRIPTION
#101 Introduced regression to can232 driver for Linux. This PR should fix it.
Signed-off-by: Kiril Petrov <vscp@geomi.org>