### PR TITLE
Fix nodeid in vscp_convertEventToCanal()

### DIFF
--- a/src/vscp/common/vscphelper.cpp
+++ b/src/vscp/common/vscphelper.cpp
@@ -1986,6 +1986,7 @@ bool vscp_convertEventToCanal(canalMsg *pcanalMsg, const vscpEvent *pvscpEvent)
 
     sizeData = pvscpEvent->sizeData;
     vscp_class = pvscpEvent->vscp_class;
+    nodeid = pvscpEvent->GUID[ 15 ];
     
     pcanalMsg->obid = pvscpEvent->obid;
     pcanalMsg->flags = 0;


### PR DESCRIPTION
Messages logged by level I logger driver has id ending to zero instead
of node id.
For example when message is coming from node with ID = 01 it should be logged to file as:
Fri Jun 10 22:57:39 2016 - B21FFB40 00000001 0C1408**01** 03 00 00 00
instead of:
Fri Jun 10 22:57:39 2016 - B21FFB40 00000001 0C140800 03 00 00 00

Signed-off-by: Kiril Petrov <vscp@geomi.org>