### PR TITLE
Fix Windows CI CMake generator selection

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Configure CMake
       run: |
-        cmake -B ${{github.workspace}}/build -G "Visual Studio 17 2022" -A x64 `
+        cmake -S ${{github.workspace}} -B ${{github.workspace}}/build `
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} `
           -DVCPKG_TARGET_TRIPLET=x64-windows `
           -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake


### PR DESCRIPTION
## Summary
- remove hardcoded `Visual Studio 17 2022` generator from the Windows workflow
- configure CMake with explicit source/build paths and keep vcpkg toolchain/triplet settings
- allow CMake to select an available generator on the runner

## Problem
Windows CI failed during CMake configure with:
`Generator Visual Studio 17 2022 could not find any instance of Visual Studio.`

## Fix
Use generator-agnostic configure invocation in `.github/workflows/build-windows.yml` by switching to:
`cmake -S <workspace> -B <workspace>/build ...`
